### PR TITLE
Content type not identifying html

### DIFF
--- a/src/MsGraphMailTransport.php
+++ b/src/MsGraphMailTransport.php
@@ -106,7 +106,7 @@ class MsGraphMailTransport extends Transport {
             'bccRecipients' => $this->toRecipientCollection($message->getBcc()),
             'importance' => $priority === 3 ? 'Normal' : ($priority < 3 ? 'Low' : 'High'),
             'body' => [
-                'contentType' => Str::contains($message->getContentType(), ['text', 'plain']) ? 'text' : 'html',
+                'contentType' => Str::contains($message->getContentType(), 'html') ? 'html' : 'text',
                 'content' => $message->getBody(),
             ],
             'attachments' => $this->toAttachmentCollection($attachments),


### PR DESCRIPTION
Logic changed to check if content type contains  "html" so marked as HTML if not  it will be a "text" content type